### PR TITLE
[releaser-dispatch] Test input version for semver format (instead of refs)

### DIFF
--- a/action-releaser-dispatch/README.md
+++ b/action-releaser-dispatch/README.md
@@ -1,12 +1,18 @@
 # action-releaser-dispatch
 
-Make GitHub dispatch call with `pre-release` event to trigger release process
+Make GitHub dispatch call with `pre-release` event to trigger release process.
 
-## Requires
+The action will only trigger if the required environment variable `VERSION` is semantic version `vX.Y.Z`, if not then it will continue without error.
 
-- `- uses: qlik-oss/ci-tools/action-version@master` - Version
-- `GH_PAT` GitHub Personal Access Token
-- Workflow that is triggered on tag `v*.*.*` push
+## Required environment variables
+
+- `GH_PAT` - GitHub Personal Access Token
+- `VERSION` - Environment variable
+
+### If used in full Github action workflow
+
+- `- uses: qlik-oss/ci-tools/action-version@master` - This actions automatically set required Version variable as required by this action
+- Workflow is triggered on tag `v*.*.*` push
 
 ## Use in GitHub Actions - workflow
 
@@ -15,6 +21,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  pull_request:
 [...]
 jobs:
   somejob:

--- a/action-releaser-dispatch/main.sh
+++ b/action-releaser-dispatch/main.sh
@@ -1,19 +1,22 @@
 #!/bin/bash -l
 set -euo pipefail
 
-if ! echo $GITHUB_REF | grep -E 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'; then
+# Strip v prefix
+VERSION=${VERSION#v}
+
+if ! echo $VERSION | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'; then
     echo "This is not a release tag, skip."
     exit 0
-else
-    VERSION=${GITHUB_REF##*/}
 fi
+
+VERSION="v${VERSION}"
 
 GH_REPO=${GITHUB_REPOSITORY#*/}
 
 body_template='{"event_type":"pre-release","client_payload":{"repository":"%s","tag":"%s"}}'
 body=$(printf $body_template "$GH_REPO" "$VERSION")
 
-curl --location --request POST "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/dispatches" \
+curl --fail --location --request POST "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/dispatches" \
     --header "Authorization: token ${GH_PAT}" \
     --header "Content-Type: application/json" \
     --data ${body}


### PR DESCRIPTION
This change allow the action to be run by setting Version variable instead of it relying on pushed refs/tags, for example if the trigger is Workflow/Repository dispatch.