### PR TITLE
[helm-tools] Lint subcharts

### DIFF
--- a/action-helm-tools/package.sh
+++ b/action-helm-tools/package.sh
@@ -34,4 +34,4 @@ echo "==> Helm package"
 runthis "helm package $CHART_DIR --version $VERSION --app-version $VERSION"
 
 echo "==> Linting"
-runthis "helm lint $CHART_NAME-$VERSION.tgz"
+runthis "helm lint $CHART_NAME-$VERSION.tgz --with-subcharts"


### PR DESCRIPTION
If a subchart does not pass linting catch it earlier before deploying the chart. It also points to which subchart needs updating instead of just an error during install.