### PR TITLE
Add basic support for handling multiple charts

### DIFF
--- a/action-helm-tools/common.sh
+++ b/action-helm-tools/common.sh
@@ -100,7 +100,7 @@ setup_kind() {
     if ! command -v kind; then
         install_kind
     fi
-    kind create cluster --image ${KIND_IMAGE}
+    kind create cluster --image ${KIND_IMAGE} --name ${CHART_NAME}
 }
 
 yaml_lint() {


### PR DESCRIPTION
Add unique name to kind cluster to support multiple calls.
Futher improvements could include support for a single call to action-helm-tools providing a directory with multiple chart definitions.