### PR TITLE
[version] git describe match tags starting with vSemVer

### DIFF
--- a/action-version/main.sh
+++ b/action-version/main.sh
@@ -23,7 +23,7 @@ fi
 # On PR actions/checkout checkouts a merge commit instead of commit sha, git describe
 # returns merge commit. To avoid this unpredictable commit sha, we will describe
 # the actual commit
-git_rev=$(git describe --tags --abbrev=7 ${_sha})
+git_rev=$(git describe --tags --abbrev=7 ${_sha} --match "v*")
 
 # If no version is returned from git describe, generate one
 [ -z "$git_rev" ] && git_rev="v0.0.0-0-g${_sha:0:7}"

--- a/action-version/main.sh
+++ b/action-version/main.sh
@@ -23,7 +23,7 @@ fi
 # On PR actions/checkout checkouts a merge commit instead of commit sha, git describe
 # returns merge commit. To avoid this unpredictable commit sha, we will describe
 # the actual commit
-git_rev=$(git describe --tags --abbrev=7 ${_sha} --match "v*")
+git_rev=$(git describe --tags --abbrev=7 ${_sha} --match "v[0-9]*.[0-9]*.[0-9]*")
 
 # If no version is returned from git describe, generate one
 [ -z "$git_rev" ] && git_rev="v0.0.0-0-g${_sha:0:7}"


### PR DESCRIPTION
Ignore tags not starting with `vX.Y.Z`