### PR TITLE
Implement helm push to ghcr.io

### DIFF
--- a/action-helm-tools/common.sh
+++ b/action-helm-tools/common.sh
@@ -23,7 +23,10 @@ get_component_properties() {
     export CHART_NAME
     if [ -z "$CHART_NAME" ]; then
         CHART_NAME=$(yq e '.components[0].componentId-helm' components.yaml)
-        if [ "$CHART_NAME" = "null" ]; then
+        if [[ "$CHART_NAME" == "null" ]]; then
+            CHART_NAME=$(yq e '.components[0].componentId' components.yaml)  # Default is componentId
+        fi
+        if [[ "$CHART_NAME" == "null" ]]; then
             echo "::error file=components.yaml::Cannot get componentId-helm from components.yaml"
             exit 1
         fi

--- a/action-helm-tools/publish.sh
+++ b/action-helm-tools/publish.sh
@@ -8,12 +8,26 @@ export JFROG_CLI_OFFER_CONFIG=false
 
 install_jfrog
 
-echo "==> Check published version of $CHART_NAME"
+if [[ -n "$PUBLISH_TO_REGISTRY" ]] && [[ "$PUBLISH_TO_REGISTRY" == "$GHCR_HELM_DEV_REGISTRY" ]]; then
+  export HELM_EXPERIMENTAL_OCI=1
 
-if jfrog rt s "$HELM_REPO/$CHART_NAME-$VERSION.tgz" --url $REGISTRY --apikey $ARTIFACTORY_PASSWORD --fail-no-op; then
-    printf "$CHART_NAME-$VERSION already exist in artifactory $HELM_REPO, exit\n"
-    exit 0
+  echo "==> Publish to GHCR"
+
+  echo "====> Saving chart $CHART_NAME:$VERSION"
+	helm chart save $CHART_DIR $GHCR_HELM_DEV_REGISTRY/$CHART_NAME:$VERSION
+
+  echo "====> Pushing chart $CHART_NAME:$VERSION to GHCR"
+	helm chart push $GHCR_HELM_DEV_REGISTRY/$CHART_NAME:$VERSION
+  echo "====> Chart $CHART_NAME:$VERSION pushed to GHCR"
 else
-    printf "==> Attempting to upload:\n$CHART_NAME-$VERSION.tgz to $HELM_REPO $REGISTRY\n\n"
-    jfrog rt u $CHART_NAME-$VERSION.tgz $HELM_REPO --url $REGISTRY --apikey $ARTIFACTORY_PASSWORD --fail-no-op || exit 1
+  echo "==> Publish to Artifactory"
+  echo "====> Check published version of $CHART_NAME"
+
+  if jfrog rt s "$HELM_REPO/$CHART_NAME-$VERSION.tgz" --url $REGISTRY --apikey $ARTIFACTORY_PASSWORD --fail-no-op; then
+      printf "$CHART_NAME-$VERSION already exist in artifactory $HELM_REPO, exit\n"
+      exit 0
+  else
+      printf "==> Attempting to upload:\n$CHART_NAME-$VERSION.tgz to $HELM_REPO $REGISTRY\n\n"
+      jfrog rt u $CHART_NAME-$VERSION.tgz $HELM_REPO --url $REGISTRY --apikey $ARTIFACTORY_PASSWORD --fail-no-op || exit 1
+  fi
 fi


### PR DESCRIPTION
The env variable `PUBLISH_TO_REGISTRY` determines if pushes go to ghcr.io or Artifactory.
If the variable is set and equal to `GHCR_HELM_DEV_REGISTRY` then the chart will be published to ghcr.io
else it will be published to Artifactory

These two PRs have succesfully published to ghcr.io from this branch:
* https://github.com/qlik-trial/messaging/pull/79
* https://github.com/qlik-trial/message-delivery-monitor/pull/195
