### PR TITLE
Changed the QR trigger

### DIFF
--- a/action-releaser-dispatch/README.md
+++ b/action-releaser-dispatch/README.md
@@ -1,6 +1,6 @@
 # action-releaser-dispatch
 
-Make GitHub dispatch call with `draft-release` event to trigger release process.
+Make GitHub dispatch call with `release` event to trigger release process.
 
 The action will only trigger if the required environment variable `VERSION` is semantic version `vX.Y.Z`, if not then it will continue without error.
 

--- a/action-releaser-dispatch/main.sh
+++ b/action-releaser-dispatch/main.sh
@@ -15,7 +15,7 @@ GH_REPO=${GITHUB_REPOSITORY#*/}
 
 BRANCH_TO_RELEASE_FROM=${BRANCH_TO_RELEASE_FROM:=""}
 
-body_template='{"event_type":"draft-release","client_payload":{"repository":"%s","tag":"%s","branch_to_release_from":"%s"}}'
+body_template='{"event_type":"release","client_payload":{"repository":"%s","tag":"%s","branch_to_release_from":"%s"}}'
 body=$(printf $body_template "$GH_REPO" "$VERSION" "$BRANCH_TO_RELEASE_FROM")
 
 # This block should be removed when GH_PAT is no longer used by any client workflows


### PR DESCRIPTION
Changed the QR trigger to "release", to avoid the somewhat confusing workflow title "draft-release". Should not be merged until the new QR has been distributed.

Signed-off-by: Emil Englesson <eng@qlik.com>