### PR TITLE
Handle both GHCR_XXXX and QLIK_XXXX in action-helm-tools

### DIFF
--- a/action-helm-tools/common.sh
+++ b/action-helm-tools/common.sh
@@ -95,6 +95,12 @@ add_helm_repos() {
     "prometheus-community https://prometheus-community.github.io/helm-charts"
   )
 
+  if [ -z "$GHCR_HELM_DEV_REGISTRY" ]; then
+    GHCR_HELM_DEV_REGISTRY=$QLIK_HELM_DEV_REGISTRY
+    GHCR_HELM_DEV_PASSWORD=$QLIK_HELM_DEV_PASSWORD
+    GHCR_HELM_DEV_USERNAME=$QLIK_HELM_DEV_USERNAME
+  fi
+
   echo "==> Helm add repo"
   if [ -n "$GHCR_HELM_DEV_REGISTRY" ]; then
     echo "==> Helm registry login"

--- a/action-helm-tools/publish.sh
+++ b/action-helm-tools/publish.sh
@@ -6,6 +6,10 @@ get_component_properties
 
 export HELM_EXPERIMENTAL_OCI=1
 
+if [ -z "$GHCR_HELM_DEV_REGISTRY" ]; then
+  GHCR_HELM_DEV_REGISTRY=$QLIK_HELM_DEV_REGISTRY
+fi
+
 echo "==> Publish to GHCR"
 
 echo "====> Saving chart $CHART_NAME:$VERSION"

--- a/action-helm-tools/test.sh
+++ b/action-helm-tools/test.sh
@@ -13,6 +13,12 @@ add_helm_repos
 echo "==> Deploy chart $CHART_NAME"
 kubectl create namespace $CHART_NAME
 
+if [ -z "$GHCR_DOCKER_DEV_REGISTRY" ]; then
+  GHCR_DOCKER_DEV_REGISTRY=$QLIK_DOCKER_DEV_REGISTRY
+  GHCR_DOCKER_DEV_PASSWORD=$QLIK_DOCKER_DEV_PASSWORD
+  GHCR_DOCKER_DEV_USERNAME=$QLIK_DOCKER_DEV_USERNAME
+fi
+
 if [[ -n "$K8S_DOCKER_REGISTRY_SECRET" ]]; then
     if [[ -n "$GHCR_DOCKER_DEV_REGISTRY" ]] && [[ "$K8S_DOCKER_REGISTRY" == "$GHCR_DOCKER_DEV_REGISTRY" ]]; then
         echo "====> GHCR docker registry"


### PR DESCRIPTION
Until all component repositories have switched to use QLIK_XXXX
instead of GHCR_XXXX, action-helm-tools should be able to handle
both GHCR_XXXX and QLIK_XXXX.