### PR TITLE
helm: Set KIND create timeout to 3min

### DIFF
--- a/action-helm-tools/common.sh
+++ b/action-helm-tools/common.sh
@@ -123,27 +123,28 @@ install_jfrog() {
     fi
 }
 
-setup_kind() {
+setup_kind_internal() {
     echo "==> Setting up KIND (Kubernetes in Docker)"
 
-    while [[ $SECONDS -lt $((SECONDS+30)) ]]; do
-      if ! command -v kind; then
-          echo "==> Get KIND:${KIND_VERSION}"
-          curl -Lso ./kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
-      fi
+    if ! command -v kind; then
+        echo "==> Get KIND:${KIND_VERSION}"
+        curl -Lso ./kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
+        chmod +x ./kind
+        sudo mv ./kind /usr/local/bin/kind
+    fi
 
-      clusters=$(kind get clusters -q)
+    clusters=$(kind get clusters -q)
 
-      if [ -z "$clusters" ]; then
-          if kind create cluster --image ${KIND_IMAGE} --name ${CHART_NAME}; then
-            break
-          fi
-      else
-          echo "KIND cluster already exist, continue"
-      fi
-    done
+    if [ -z "$clusters" ]; then
+        kind create cluster --image ${KIND_IMAGE} --name ${CHART_NAME}
+    else
+        echo "KIND cluster already exist, continue"
+    fi
+}
+
+setup_kind() {
+  export -f setup_kind_internal
+  timeout 30s bash -c setup_kind_internal
 }
 
 yaml_lint() {

--- a/action-helm-tools/common.sh
+++ b/action-helm-tools/common.sh
@@ -144,7 +144,11 @@ setup_kind_internal() {
 
 setup_kind() {
   export -f setup_kind_internal
-  timeout 30s bash -c setup_kind_internal
+  timeout 180s bash -c setup_kind_internal || EXITCODE=$?
+  if [ $EXITCODE != 0 ]; then
+      echo "::error ::Kubernetes (in Docker) setup timed out. Usually intermittent, re-run the job to try again"
+      exit 1
+  fi
 }
 
 yaml_lint() {

--- a/action-helm-tools/common.sh
+++ b/action-helm-tools/common.sh
@@ -123,26 +123,27 @@ install_jfrog() {
     fi
 }
 
-install_kind() {
-    echo "==> Get KIND:${KIND_VERSION}"
-    curl -Lso ./kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
-    chmod +x ./kind
-    sudo mv ./kind /usr/local/bin/kind
-}
-
 setup_kind() {
     echo "==> Setting up KIND (Kubernetes in Docker)"
-    if ! command -v kind; then
-        install_kind
-    fi
 
-    clusters=$(kind get clusters -q)
+    while [[ $SECONDS -lt $((SECONDS+30)) ]]; do
+      if ! command -v kind; then
+          echo "==> Get KIND:${KIND_VERSION}"
+          curl -Lso ./kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+      fi
 
-    if [ -z "$clusters" ]; then
-      kind create cluster --image ${KIND_IMAGE} --name ${CHART_NAME}
-    else
-      echo "KIND cluster already exist, continue"
-    fi
+      clusters=$(kind get clusters -q)
+
+      if [ -z "$clusters" ]; then
+          if kind create cluster --image ${KIND_IMAGE} --name ${CHART_NAME}; then
+            break
+          fi
+      else
+          echo "KIND cluster already exist, continue"
+      fi
+    done
 }
 
 yaml_lint() {


### PR DESCRIPTION
Setting up KIND should not take more than 2 minutes, enforce a timeout so that the step does not run indefinitely in case there are issues with the runner, GitHub or download of KIND.