### PR TITLE
chore: helm.min.io no longer responding

### DIFF
--- a/action-helm-tools/common.sh
+++ b/action-helm-tools/common.sh
@@ -87,7 +87,6 @@ add_helm_repos() {
 
   public_repos=(
     "bitnami https://charts.bitnami.com/bitnami"
-    "minio https://helm.min.io/"
     "dandydev https://dandydeveloper.github.io/charts"
     "stable https://charts.helm.sh/stable"
     "ingress-nginx https://kubernetes.github.io/ingress-nginx"


### PR DESCRIPTION
bitnami is the chart repo to use for minio charts.
I haven't yet found any of our QCS charts that uses `@minio`