### PR TITLE
Quick fix for semver/bumping patch version for dev releases

### DIFF
--- a/action-version/main.sh
+++ b/action-version/main.sh
@@ -23,7 +23,7 @@ fi
 # On PR actions/checkout checkouts a merge commit instead of commit sha, git describe
 # returns merge commit. To avoid this unpredictable commit sha, we will describe
 # the actual commit
-git_rev=$(git describe --tags --abbrev=7 ${_sha} --match "v[0-9]*.[0-9]*.[0-9]*")
+git_rev=$(git describe --tags --abbrev=7 ${_sha} --match "v[0-9]*.[0-9]*.[0-9]*" | perl -ne 'm/(^v)(\d+\.\d+\.)(\d+)(.*$)/ && print $1 . $2 . int(1+$3) . $4')
 
 # If no version is returned from git describe, generate one
 [ -z "$git_rev" ] && git_rev="v0.0.0-0-g${_sha:0:7}"


### PR DESCRIPTION
This will make sure that the patch version is bumped when creating dev tags.

Example:
`v3.3.9-9-g038da41`becomes `v3.3.10-9-g038da41`
`vMAJOR.MINOR.PATCH-NUMBEROFCOMMITSSINCETAG-COMMITREF`