### PR TITLE
Remove g

### DIFF
--- a/action-version/README.md
+++ b/action-version/README.md
@@ -8,8 +8,8 @@ Sets output and environment variable that can be used in subsequent GitHub Actio
 
 Returns version based on `git describe --tags --abbrev=7`, see https://git-scm.com/docs/git-describe for more details
 
-- `1.2.3-n.g<short-commit-sha>` - Most recent tag - number of commits since tag - short commit sha preffixed with g
-- `0.0.0-0.g<short-commit-sha>` - When no tags are available it returns version `0.0.0-0` and short commit sha
+- `1.2.3-n.<short-commit-sha>` - Most recent tag - number of commits since tag - short commit sha
+- `0.0.0-0.<short-commit-sha>` - When no tags are available it returns version `0.0.0-0` and short commit sha
 - `1.2.3` - If a tag `v*.*.*` is pushed (a release tag), it will return the same tag without describing git repository
 
 *`v` (version) prefix is omitted in all cases*

--- a/action-version/main.sh
+++ b/action-version/main.sh
@@ -32,11 +32,11 @@ git_rev=$(git describe --tags --abbrev=7 ${_sha} --match "v[0-9]*.[0-9]*.[0-9]*"
 # An exact semver does not contain a '-'
 if [[ "$git_rev" == *-* ]]; then
   # Transforms 0.0.0-0-g1234abc to 0.0.1-0.g123abc
-  git_rev=$(echo $git_rev | perl -ne 'm/(^v\d+\.\d+\.)(\d+)(.*)(\-g)(.*$)/ && print $1 . int(1+$2) . $3 . ".g" . $5')
+  git_rev=$(echo $git_rev | perl -ne 'm/(^v\d+\.\d+\.)(\d+)(.*)(\-g)(.*$)/ && print $1 . int(1+$2) . $3 . "." . $5')
 fi
 
 # If no version is returned from git describe, generate one
-[ -z "$git_rev" ] && git_rev="v0.0.0-0.g${_sha:0:7}"
+[ -z "$git_rev" ] && git_rev="v0.0.0-0.${_sha:0:7}"
 
 # Return Version without v prefix
 VERSION=${git_rev#v}


### PR DESCRIPTION
We don't need the `g` prefix to the commit sha.