### PR TITLE
chore: workaround for CVE-2022-24765

### DIFF
--- a/action-run-cmd-create-pr/entrypoint.sh
+++ b/action-run-cmd-create-pr/entrypoint.sh
@@ -23,6 +23,8 @@ echo "---------------------------------------------------"
 
 
 git branch -r
+echo "Asking git to accept ${GITHUB_WORKSPACE} as a safe directory"
+git config --global --add safe.directory ${GITHUB_WORKSPACE}
 # Clone repository and run command
 git clone https://${INPUT_GH_TOKEN}@github.com/${INPUT_OWNER}/${INPUT_REPOSITORY}.git ${INPUT_BASE_BRANCH}
 cd ${INPUT_REPOSITORY}


### PR DESCRIPTION
The action is currently broken due to new safe guards of git refusing to do git operations in workspaces not owned by the executing user. This is an implementation of the proposed workaround https://github.blog/2022-04-12-git-security-vulnerability-announced/