### PR TITLE
feature: merge component into values file

### DIFF
--- a/action-helm-tools/common.sh
+++ b/action-helm-tools/common.sh
@@ -15,7 +15,7 @@ export KUBECTL_VERSION=${KUBECTL_VERSION:="1.20.7"}
 export KIND_VERSION=${KIND_VERSION:="v0.11.1"}
 # Get Image version from https://github.com/kubernetes-sigs/kind/releases, look for K8s version in the release notes
 export KIND_IMAGE=${KIND_IMAGE:="kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9"}
-export YQ_VERSION="4.6.0"
+export YQ_VERSION="4.25.2"
 
 get_component_properties() {
     install_yq

--- a/action-helm-tools/package.sh
+++ b/action-helm-tools/package.sh
@@ -13,6 +13,9 @@ $SCRIPT_DIR/qlikcommon-check.sh
 echo "==> Helm dependency build"
 helm dependency build "$CHART_DIR"
 
+echo "==> Merging component metadata"
+yq '.component |= load("component.yaml")' "$CHART_DIR/values.yaml"
+
 if [ "$IMAGE_TAG_UPDATE" = "false" ]; then
   echo "==> Skip updating image.tag due to IMAGE_TAG_UPDATE=$IMAGE_TAG_UPDATE"
 else

--- a/action-helm-tools/package.sh
+++ b/action-helm-tools/package.sh
@@ -14,7 +14,7 @@ echo "==> Helm dependency build"
 helm dependency build "$CHART_DIR"
 
 echo "==> Merging component metadata"
-yq '.component |= load("component.yaml")' "$CHART_DIR/values.yaml"
+yq -i '.component |= load("component.yaml")' "$CHART_DIR/values.yaml"
 
 if [ "$IMAGE_TAG_UPDATE" = "false" ]; then
   echo "==> Skip updating image.tag due to IMAGE_TAG_UPDATE=$IMAGE_TAG_UPDATE"


### PR DESCRIPTION
merge `component.yaml` into `values.yaml`, allow using component metadata in helm chart.

proof that it works:
```
EU-etq:qdi-app-manager etq$ helm chart pull ghcr.io/qlik-trial/helm/qdi-app-manager:1.11.4-18-g6d4bcb0
1.11.4-18-g6d4bcb0: Pulling from ghcr.io/qlik-trial/helm/qdi-app-manager
ref:     ghcr.io/qlik-trial/helm/qdi-app-manager:1.11.4-18-g6d4bcb0
digest:  b6061afb7f81384bf3dffc7198c5c06892b1d7ca15da61e0fb75d535316fcf27
size:    121.9 KiB
name:    qdi-app-manager
version: 1.11.4-18-g6d4bcb0
Status: Downloaded newer chart for ghcr.io/qlik-trial/helm/qdi-app-manager:1.11.4-18-g6d4bcb0
EU-etq:qdi-app-manager etq$ cd /tmp
EU-etq:tmp etq$ helm chart export ghcr.io/qlik-trial/helm/qdi-app-manager:1.11.4-18-g6d4bcb0
ref:     ghcr.io/qlik-trial/helm/qdi-app-manager:1.11.4-18-g6d4bcb0
digest:  56a372bf32b3d17844b4721db144ae0e1c3df9f7936beb0b2dd32fda4e29313e
size:    121.9 KiB
name:    qdi-app-manager
version: 1.11.4-18-g6d4bcb0
Exported chart to qdi-app-manager/
EU-etq:tmp etq$ cd qdi-app-manager/
EU-etq:qdi-app-manager etq$ cat values.yaml 
image:
  registry: ghcr.io/qlik-trial
  repository: qdi-app-manager
  tag: 1.11.4-18-g6d4bcb0
  pullPolicy: IfNotPresent
  pullSecrets:
    - name: artifactory-docker-secret
configs:
...
...
component:
  componentId: qdi-app-manager
  repository: qdi-app-manager
  domain: data-integration
  discussionSlackChannel: '#dis-core-scrumteam'
  botSlackChannel: '#dis-core-scrumteam'
  owningTeam: dis-core
  qlik-releaser: true
  publishedPackages:
    docker:
      ids:
        - qdi-app-manager
    helm:
      ids:
        - qdi-app-manager
  production-approval: required
  production-approval/compliance/antivirus: required
  production-approval/compliance/api-governance: required
  production-approval/compliance/blackduck: required
  production-approval/compliance/twistlock: required
  primaryChampion: rlsf
  secondaryChampions:
    - mahmoud-aamar
    - mikigeorge
```