### PR TITLE
bugfix: query qlik-prod instead of qlik-trial for own chart releases

### DIFF
--- a/action-helm-tools/dependencies.sh
+++ b/action-helm-tools/dependencies.sh
@@ -51,7 +51,7 @@ helm_dependency_updater() {
   for dep in "${deps[@]}"; do
     IFS=";" read -r -a d <<< "${dep}"
       echo "Checking for new version of ${d[0]}:${d[1]}"
-      latest_chart_version=$(curl -s -X GET -H "Authorization: Bearer $(echo $GITHUB_TOKEN | base64)" https://ghcr.io/v2/qlik-trial/helm/${d[0]}/tags/list | jq -r '.tags | sort | .[] | select(test("^[0-9]+.[0-9]+.[0-9]+$"))' | tail -n 1)
+      latest_chart_version=$(curl -s -X GET -H "Authorization: Bearer $(echo $GITHUB_TOKEN | base64)" https://ghcr.io/v2/qlik-prod/helm/${d[0]}/tags/list | jq -r '.tags | sort | .[]' | tail -n 1)
       echo "Latest available version ${d[0]}:$latest_chart_version"
       if semver -r ">${d[1]}" $latest_chart_version; then
         echo "Update ${d[0]}:${d[1]} to $latest_chart_version"


### PR DESCRIPTION
* no need to filter out intermediate artifacts.
* much smaller list, so no need to use pagination to retrieve latest releases (at least until we have 100 releases).