### PR TITLE
Remove dependencies to QLIK_XXXX

### DIFF
--- a/action-helm-tools/common.sh
+++ b/action-helm-tools/common.sh
@@ -9,6 +9,9 @@ export HELM_LOCAL_REPO=${HELM_LOCAL_REPO:="qlik"}
 export K8S_DOCKER_EMAIL=${K8S_DOCKER_EMAIL:="xyz@example.com"}
 export DEPENDENCY_UPDATE=${DEPENDENCY_UPDATE:="false"}
 
+export DOCKER_DEV_REGISTRY="ghcr.io/qlik-trial"
+export HELM_DEV_REGISTRY="ghcr.io/qlik-trial/helm"
+
 # Tools
 export HELM_VERSION=${HELM_VERSION:="3.6.3"}
 export KUBECTL_VERSION=${KUBECTL_VERSION:="1.20.7"}
@@ -100,7 +103,11 @@ add_helm_repos() {
   # charts.appscode.com currently not working, get builds working angain and figure out what breaks because kubed is missing instead
 
   echo "==> Helm add repo"
-  if [ -n "$QLIK_HELM_DEV_REGISTRY" ]; then
+  if [[ -n "$GITHUB_USER" ]] && [[ -n "$GITHUB_TOKEN" ]]; then
+    echo "==> Helm registry login (registry is $HELM_DEV_REGISTRY)"
+    echo $GITHUB_TOKEN | helm registry login --username $GITHUB_USER --password-stdin https://$HELM_DEV_REGISTRY
+  elif [ -n "$QLIK_HELM_DEV_REGISTRY" ]; then
+    # TODO: Remove this block when it is no longer used
     echo "==> Helm registry login"
     echo $QLIK_HELM_DEV_PASSWORD | helm registry login --username $QLIK_HELM_DEV_USERNAME --password-stdin https://$QLIK_HELM_DEV_REGISTRY
   fi

--- a/action-helm-tools/publish.sh
+++ b/action-helm-tools/publish.sh
@@ -9,8 +9,8 @@ export HELM_EXPERIMENTAL_OCI=1
 echo "==> Publish to GHCR"
 
 echo "====> Saving chart $CHART_NAME:$VERSION"
-helm chart save $CHART_NAME-$VERSION.tgz $QLIK_HELM_DEV_REGISTRY/$CHART_NAME:$VERSION
+helm chart save $CHART_NAME-$VERSION.tgz $HELM_DEV_REGISTRY/$CHART_NAME:$VERSION
 
-echo "====> Pushing chart $CHART_NAME:$VERSION to GHCR"
-helm chart push $QLIK_HELM_DEV_REGISTRY/$CHART_NAME:$VERSION
-echo "====> Chart $CHART_NAME:$VERSION pushed to GHCR"
+echo "====> Pushing chart $CHART_NAME:$VERSION to $HELM_DEV_REGISTRY"
+helm chart push $HELM_DEV_REGISTRY/$CHART_NAME:$VERSION
+echo "====> Chart $CHART_NAME:$VERSION pushed to $HELM_DEV_REGISTRY"

--- a/action-helm-tools/test.sh
+++ b/action-helm-tools/test.sh
@@ -14,12 +14,19 @@ echo "==> Deploy chart $CHART_NAME"
 kubectl create namespace $CHART_NAME
 
 if [[ -n "$K8S_DOCKER_REGISTRY_SECRET" ]]; then
-    if [[ -n "$QLIK_DOCKER_DEV_REGISTRY" ]] && [[ "$K8S_DOCKER_REGISTRY" == "$QLIK_DOCKER_DEV_REGISTRY" ]]; then
-        echo "====> GHCR docker registry"
+    if [[ -n "$GITHUB_USER" ]] && [[ -n "$GITHUB_TOKEN" ]] && [[ "$K8S_DOCKER_REGISTRY" == "$DOCKER_DEV_REGISTRY" ]]; then
+        echo "====> Create secret for docker registry (registry is $DOCKER_DEV_REGISTRY)"
+        kubectl create secret docker-registry --namespace $CHART_NAME $K8S_DOCKER_REGISTRY_SECRET \
+            --docker-server=$K8S_DOCKER_REGISTRY --docker-username=$GITHUB_USER \
+            --docker-password=$GITHUB_TOKEN --docker-email=$K8S_DOCKER_EMAIL
+    elif [[ -n "$QLIK_DOCKER_DEV_REGISTRY" ]] && [[ "$K8S_DOCKER_REGISTRY" == "$QLIK_DOCKER_DEV_REGISTRY" ]]; then
+        # TODO: Remove this block when it is no longer used
+        echo "====> Create secret for docker registry"
         kubectl create secret docker-registry --namespace $CHART_NAME $K8S_DOCKER_REGISTRY_SECRET \
             --docker-server=$K8S_DOCKER_REGISTRY --docker-username=$QLIK_DOCKER_DEV_USERNAME \
             --docker-password=$QLIK_DOCKER_DEV_PASSWORD --docker-email=$K8S_DOCKER_EMAIL
     else
+        # TODO: Change the output in this block when the elif block is removed
         echo "QLIK_DOCKER_DEV_REGISTRY: ${QLIK_DOCKER_DEV_REGISTRY}"
         echo "K8S_DOCKER_REGISTRY: ${K8S_DOCKER_REGISTRY}"
         echo "Error: Unexpected value for QLIK_DOCKER_DEV_REGISTRY and/or K8S_DOCKER_REGISTRY"


### PR DESCRIPTION
The "Package helm" workflow, which uses action-helm-tools, should be closer integrated with Qlik Releaser. Therefore, similar to Qlik Releaser, action-helm-tools should use environment variables GITHUB_USER and GITHUB_TOKEN instead of

QLIK_DOCKER_DEV_USERNAME
QLIK_HELM_DEV_USERNAME
QLIK_DOCKER_DEV_PASSWORD
QLIK_HELM_DEV_PASSWORD

and use hard coded values "ghcr.io/qlik-trial" and "ghcr.io/qlik-trial/helm" instead of environment variables QLIK_DOCKER_DEV_REGISTRY and QLIK_HELM_DEV_REGISTRY.