### PR TITLE
Use qr_package-helm-chart.yaml instead of package-helm.yaml

### DIFF
--- a/scripts-circleci/github-package-helm-dispatch.sh
+++ b/scripts-circleci/github-package-helm-dispatch.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 VERSION_FILE=${VERSION_FILE:="/workspace/version.txt"}
-GITHUB_WORKFLOW=${GITHUB_WORKFLOW:="package-helm.yaml"}
+GITHUB_WORKFLOW=${GITHUB_WORKFLOW:="qr_package-helm-chart.yaml"}
 
 if [ -z "${VERSION}" ]; then
   VERSION=$(cat "$VERSION_FILE")
@@ -44,7 +44,8 @@ else
   REF=${CIRCLE_BRANCH}
 fi
 
-generate_post_data()
+# TODO: Remove this function when package-helm.yaml is no longer used in any component repository
+generate_post_data_old()
 {
   cat <<EOF
 {
@@ -57,8 +58,25 @@ generate_post_data()
 EOF
 }
 
+generate_post_data()
+{
+  cat <<EOF
+{
+  "ref": "${REF}",
+  "inputs": {
+    "version": "${VERSION}",
+    "commit_sha": "${GIT_COMMIT}"
+  }
+}
+EOF
+}
+
 echo "Data:"
-generate_post_data
+if [ "${GITHUB_WORKFLOW}" == "qr_package-helm-chart.yaml" ]; then
+  generate_post_data
+else
+  generate_post_data_old
+fi
 
 curl -i --fail --location --request POST "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/actions/workflows/${GITHUB_WORKFLOW}/dispatches" \
   --header "Authorization: token ${GH_ACCESS_TOKEN}" \

--- a/scripts-jenkins/github-package-helm-dispatch.sh
+++ b/scripts-jenkins/github-package-helm-dispatch.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 VERSION_FILE=${VERSION_FILE:="/workspace/version.txt"}
-GITHUB_WORKFLOW=${GITHUB_WORKFLOW:="package-helm.yaml"}
+GITHUB_WORKFLOW=${GITHUB_WORKFLOW:="qr_package-helm-chart.yaml"}
 
 if [ -z "${VERSION}" ]; then
   VERSION=$(cat "$VERSION_FILE")
@@ -36,7 +36,8 @@ else
   REF=${GIT_BRANCH}
 fi
 
-generate_post_data()
+# TODO: Remove this function when package-helm.yaml is no longer used in any component repository
+generate_post_data_old()
 {
   cat <<EOF
 {
@@ -49,8 +50,25 @@ generate_post_data()
 EOF
 }
 
+generate_post_data()
+{
+  cat <<EOF
+{
+  "ref": "${REF}",
+  "inputs": {
+    "version": "${VERSION}",
+    "commit_sha": "${GIT_COMMIT}"
+  }
+}
+EOF
+}
+
 echo "Data:"
-generate_post_data
+if [ "${GITHUB_WORKFLOW}" == "qr_package-helm-chart.yaml" ]; then
+  generate_post_data
+else
+  generate_post_data_old
+fi
 
 curl -i --fail --location --request POST "https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPONAME}/actions/workflows/${GITHUB_WORKFLOW}/dispatches" \
   --header "Authorization: token ${GH_ACCESS_TOKEN}" \


### PR DESCRIPTION
**This PR should be merged after the next major QR release, when qr_package-helm-chart.yaml is available in all component repositories.** All components whose build script runs scripts-circleci/github-package-helm-dispatch.sh or scripts-jenkins/github-package-helm-dispatch.sh (i.e. most, possibly all, components which publish helm charts and build with CCI or Jenkins) will then start to use `qlik-releaser/.github/workflows/rt_package-helm-chart.yaml` instead of `<component repo root>/.github/workflows/package-helm.yaml` for packaging and publishing helm charts. For some component repositories, this might be inappropriate. In those repositories, a rollback to the old solution, i.e. using package-helm.yaml, can be done by addition of
`export GITHUB_WORKFLOW=package-helm.yaml`
before the line that calls github-package-helm-dispatch.sh in the build script.