### PR TITLE
Bump from v2 to v3 for actions/setup-go

### DIFF
--- a/action-verify-compliance/action.yml
+++ b/action-verify-compliance/action.yml
@@ -7,7 +7,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: '1.18'
     - id: clone-repo-with-verification-commands


### PR DESCRIPTION
actions/setup-go v3 should be used instead of actions/setup-go v2, to prevent GH from warning about "Node.js 12 actions are deprecated".