### PR TITLE
Use new syntax for setting wf job outputs

### DIFF
--- a/action-docker-sha256/main.sh
+++ b/action-docker-sha256/main.sh
@@ -16,4 +16,4 @@ DOCKER_SHA256=$(docker inspect $IMAGE | jq -r '(.[].RepoDigests[0] | split(":"))
 # Set GitHub Action environment and output variable
 # DOCKER_SHA256
 echo "DOCKER_SHA256=${DOCKER_SHA256}" >> $GITHUB_ENV
-echo "::set-output name=DOCKER_SHA256::${DOCKER_SHA256}"
+echo "DOCKER_SHA256=${DOCKER_SHA256}" >> $GITHUB_OUTPUT

--- a/action-verify-compliance/action.yml
+++ b/action-verify-compliance/action.yml
@@ -32,6 +32,6 @@ runs:
         go run main.go ${TARGET_OWNER} ${TARGET_NAME} ${TARGET_REF}
         export VERIFICATION_STATUS=$(cat ${VERIFICATION_TYPE}-status.txt)
         echo ${VERIFICATION_TYPE} status: ${VERIFICATION_STATUS}
-        echo "::set-output name=verification-status::$(echo $VERIFICATION_STATUS)"
+        echo "verification-status=${VERIFICATION_STATUS}" >> $GITHUB_OUTPUT
         if [ "${VERIFICATION_STATUS}" = "failure" ] || [ "${VERIFICATION_STATUS}" = "error" ]; then exit 1; fi
       shell: bash

--- a/action-version/main.sh
+++ b/action-version/main.sh
@@ -55,16 +55,16 @@ echo "Set branch_name: ${BRANCH_NAME}"
 # Set GitHub Action environment and output variable
 # VERSION
 echo "VERSION=${VERSION}" >> $GITHUB_ENV
-echo "::set-output name=VERSION::${VERSION}"
+echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
 
 # COMMIT_SHA
 echo "COMMIT_SHA=${_sha}" >> $GITHUB_ENV
-echo "::set-output name=COMMIT_SHA::${_sha}"
+echo "COMMIT_SHA=${_sha}" >> $GITHUB_OUTPUT
 
 # BRANCH_NAME
 echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
-echo "::set-output name=BRANCH_NAME::${BRANCH_NAME}"
+echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
 
 # RELEASE TAG
 echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
-echo "::set-output name=RELEASE_TAG::${RELEASE_TAG}"
+echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
In Github workflows, the syntax
`echo "::set-output name=<name>::<value>"`
is obsolete, and should be replaced with
`echo "<name>=<value>" >> $GITHUB_OUTPUT`