### PR TITLE
Added option for `package_and_publish`

### DIFF
--- a/action-helm-tools/README.md
+++ b/action-helm-tools/README.md
@@ -13,6 +13,7 @@ _Note this action is written to specifically work with Helm repos in Artifactory
 - `test` - Creates K8s cluster (in Docker), sets up helm, install chart in a namespace and waits for all pods to be up and running
 - `publish` - Uses jfrog cli to check for existing package with same version and uploads if new chart is built
 - `package_and_test` - Run `package` and `test` in one step
+- `package_and_publish` - Run `package` and `publish`, skipping `test` for images that cannot start on their own
 
 ## Version
 

--- a/action-helm-tools/main.sh
+++ b/action-helm-tools/main.sh
@@ -19,6 +19,9 @@ main() {
     elif [[ "${INPUT_ACTION}" == "package_and_test" ]]; then
         "$SCRIPT_DIR/package.sh"
         "$SCRIPT_DIR/test.sh"
+    elif [[ "${INPUT_ACTION}" == "package_and_publish" ]]; then
+        "$SCRIPT_DIR/package.sh"
+        "$SCRIPT_DIR/publish.sh"
     else
         "$SCRIPT_DIR/$INPUT_ACTION.sh"
     fi


### PR DESCRIPTION
Right now, I've run into a case where I have a daemonset that needs to check in with a different pod at startup.
I can never pass the `test` phase with this image, and it would be fun if I could configure this unique arrangement of package, <no test>, publish.
Comments welcome!
Thanks!