### PR TITLE
Add twin and jetstack publc repos

### DIFF
--- a/action-helm-tools/common.sh
+++ b/action-helm-tools/common.sh
@@ -98,6 +98,8 @@ add_helm_repos() {
     "connaisseur https://sse-secure-systems.github.io/connaisseur/charts"
     "infracloudio https://infracloudio.github.io/charts"
     "datadog https://helm.datadoghq.com/"
+    "jetstack  https://charts.jetstack.io"
+    "twin https://twin.github.io/helm-charts"
   )
   # "kubed https://charts.appscode.com/stable/"
   # charts.appscode.com currently not working, get builds working angain and figure out what breaks because kubed is missing instead


### PR DESCRIPTION
Signed-off-by: Amir <amirghotbi@gmail.com>

jetstack:
  - Contains the cert-manager helm chart
  - [Ref](https://cert-manager.io/docs/installation/helm/#1-add-the-helm-repository)

twin:
  - Contains the aws-eks-asg-rolling-update-handler helm chart
  - [Ref](https://github.com/TwiN/aws-eks-asg-rolling-update-handler#deploying-with-helm)