### PR TITLE
[ArgoCD] Add AtgoCD Helm repo

### DIFF
--- a/action-helm-tools/common.sh
+++ b/action-helm-tools/common.sh
@@ -100,6 +100,7 @@ add_helm_repos() {
     "datadog https://helm.datadoghq.com/"
     "jetstack  https://charts.jetstack.io"
     "twin https://twin.github.io/helm-charts"
+    "argo https://argoproj.github.io/argo-helm"
   )
   # "kubed https://charts.appscode.com/stable/"
   # charts.appscode.com currently not working, get builds working angain and figure out what breaks because kubed is missing instead


### PR DESCRIPTION
Signed-off-by: Amir <amirghotbi@gmail.com>

Argo CD:
  - Contains the argo-cd helm chart
  - [Ref](https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd#installing-the-chart)
