### PR TITLE
Revert "Support dependency_update ..."

### DIFF
--- a/scripts-circleci/github-package-helm-dispatch.sh
+++ b/scripts-circleci/github-package-helm-dispatch.sh
@@ -52,8 +52,6 @@ generate_post_data()
   "inputs": {
     "version": "${VERSION}",
     "commit_sha": "${CIRCLE_SHA1}"
-    "dependency_update": "${DEPENDENCY_UPDATE}"
-    "action": "${ACTION}"
   }
 }
 EOF

--- a/scripts-jenkins/github-package-helm-dispatch.sh
+++ b/scripts-jenkins/github-package-helm-dispatch.sh
@@ -44,8 +44,6 @@ generate_post_data()
   "inputs": {
     "version": "${VERSION}",
     "commit_sha": "${GIT_COMMIT}"
-    "dependency_update": "${DEPENDENCY_UPDATE}"
-    "action": "${ACTION}"
   }
 }
 EOF


### PR DESCRIPTION
The change

Support dependency_update and action via env. variables

was reverted, since it is not yet supported by distributed qr_package-helm-chart.yaml files. The change should be done after distribution of the next major QR release (v38.0.0).