### PR TITLE
Add teleport as a public repo

### DIFF
--- a/action-helm-tools/common.sh
+++ b/action-helm-tools/common.sh
@@ -108,6 +108,7 @@ add_helm_repos() {
     "dynatrace https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable"
     "botkube https://charts.botkube.io"
     "karpenter https://charts.karpenter.sh"
+    "teleport https://charts.releases.teleport.dev"
   )
   # "kubed https://charts.appscode.com/stable/"
   # charts.appscode.com currently not working, get builds working angain and figure out what breaks because kubed is missing instead


### PR DESCRIPTION
Add teleport as a public repo
fixes:
```
==> Helm dependency build
90
Error: no repository definition for @teleport. Please add them via 'helm repo add'
91
Error: Process completed with exit code 1.
```