### PR TITLE
helm install local chart fails looking for repo in path

### DIFF
--- a/action-helm-tools/test.sh
+++ b/action-helm-tools/test.sh
@@ -67,7 +67,7 @@ if [[ "${SINGLE_NATS_STREAMING:=true}" == "true" ]]; then
   options+=(-f "${SCRIPT_DIR}/helmvalues/messaging-non-clustered.yaml")
 fi
 
-runthis "helm install $CHART_NAME $CHART_NAME-$VERSION.tgz --namespace $CHART_NAME --create-namespace $EXTRA_HELM_CMD" "${options[@]}"
+runthis "helm install $CHART_NAME .$CHART_NAME-$VERSION.tgz --namespace $CHART_NAME --create-namespace $EXTRA_HELM_CMD" "${options[@]}"
 
 sleep 30
 check_helm_deployment


### PR DESCRIPTION
Hey @mtk7801 - not sure if I'm attacking this problem from the wrong end, but in  https://github.com/qlik-trial/teleport-ent/actions/runs/4315065750/jobs/7528927741 I'm getting: 
```
helm install teleport-ent teleport-ent-0.0.0-0.g6beef92.tgz --namespace teleport-ent --create-namespace  -f /home/runner/work/_actions/qlik-oss/ci-tools/master/action-helm-tools/helmvalues/messaging-non-clustered.yaml
220
Error: INSTALLATION FAILED: non-absolute URLs should be in form of repo_name/path_to_chart, got: teleport-ent-0.0.0-0.g6beef92.tgz
221
Error: Process completed with exit code 1.
```
I think it wants a directory, so I'm trying ".", but... am I the only one hitting this error?  Maybe I've done something obviously wrong elsewhere...

Can you help, please?
Thank you!