### PR TITLE
Do exit 1 in ci-tools/action-print-event-info

### DIFF
--- a/action-print-event-info/action.yml
+++ b/action-print-event-info/action.yml
@@ -9,4 +9,5 @@ runs:
         echo GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}
         echo GITHUB_EVENT_PATH: ${GITHUB_EVENT_PATH}
         cat ${GITHUB_EVENT_PATH}
+        exit 1
       shell: bash


### PR DESCRIPTION
ci-tools/action-print-event-info has been deprecated for a month. So ci-tools/action-print-event-info should now fail when it is used, with a message that qlik-releaser/.github/actions/print-event-info should be used instead. In yet another month, ci-tools/action-print-event-info should be removed.