### PR TITLE
Always print logs for all pods in helm-deployment-check.sh

### DIFF
--- a/action-helm-tools/helm-deployment-check.sh
+++ b/action-helm-tools/helm-deployment-check.sh
@@ -39,58 +39,78 @@ while [[ $SECONDS -lt $((SECONDS+60)) ]]; do
 done
 
 get_pods() {
-  pods=$(kubectl get pods -n $NAMESPACE -o json | jq -r '.items[] | select(.status.phase? != "Running" or .status.containerStatuses[]?.ready != true) | .metadata.name' )
-  echo "Pods not ready: $pods"
+  pods=$(kubectl get pods -n $NAMESPACE -o json | jq -r '.items[] | .metadata.name' )
 }
 
-get_pods
+# An ok_pod is a pod whose deployment is OK. More exactly, an ok_pod is a pod for which the following conditions are true:
+#
+# A. status.phase == "Running"
+# B. status.containerStatuses.ready == true
+#
+# A nok_pod is a pod whose deployment is not OK, i.e. a pod for which condition A and/or B is not true.
+#
+# Note: A pod could change from being an ok_pod to being a nok_pod. In other words, pod state could degrade. For example,
+# during startup of a kubernetes cluster, a pod's status.phase value could change from "Running" to "CrashLoopBackOff".
+get_nok_pods() {
+  nok_pods=$(kubectl get pods -n $NAMESPACE -o json | jq -r '.items[] | select(.status.phase? != "Running" or .status.containerStatuses[]?.ready != true) | .metadata.name' )
+}
 
-echo "==> checking pods"
+get_nok_pods
+
+echo "==> Check pods in namespace $NAMESPACE"
 deployed=0
 _timeout=$((SECONDS+$TIMEOUT))
 while [[ $SECONDS -lt $_timeout ]]; do
-  if [[ -z "$pods" ]]; then
-    echo "All deployments are OK"
+  if [[ -z "$nok_pods" ]]; then
+    echo "All pods in namespace $NAMESPACE are OK"
     deployed=1
     break
   else
+    echo "The following pods in namespace $NAMESPACE are not OK:"
+    echo "$nok_pods"
     sleep 10
-    get_pods
+    get_nok_pods
   fi
 done
 
 if [[ $deployed == 1 ]]; then
   sleep 5
-  get_pods
-  if [[ -n "$pods" ]]; then
+  get_nok_pods
+  if [[ -n "$nok_pods" ]]; then
     echo "==> DEGRADATION"
+    # Example of pod degradation: status.phase changes from "Running" to "CrashLoopBackoff"
     # For info about CrashLoopBackOff, see https://sysdig.com/blog/debug-kubernetes-crashloopbackoff
-    echo "Some pod has degraded from 'deployment OK' to 'not ready', likely because the status phase for the pod changed from 'Running' to 'CrashLoopBackOff'"
+    echo "The following pods in namespace $NAMESPACE have degraded (changed state from 'OK' to 'not OK'):"
+    echo "$nok_pods"
     deployed=0
   fi
 fi
 
-POD_LOGS="${GITHUB_WORKSPACE}/podlogs/" && mkdir -p "${POD_LOGS}"
-echo "POD_LOGS=${POD_LOGS}" >> $GITHUB_ENV
+POD_LOGS_DIR="${GITHUB_WORKSPACE}/podlogs/" && mkdir -p "${POD_LOGS_DIR}"
+echo "POD_LOGS_DIR=${POD_LOGS_DIR}" >> $GITHUB_ENV
+
+echo "==> Print pod info for all namespaces"
+kubectl get pods --all-namespaces
+
+echo "==> Get logs for pods in namespace $NAMESPACE"
+get_pods
+for pod in $pods; do
+  set +e
+  logfile="${POD_LOGS_DIR}/${pod}.log"
+  echo "==> 'kubectl logs' for pod $pod (current container instances):" | tee -a "$logfile"
+  kubectl logs -n "$NAMESPACE" "$pod" --all-containers 2>&1 | tee -a "$logfile"
+  echo "==> 'kubectl logs' for pod $pod (previous container instances):" | tee -a "$logfile"
+  kubectl logs -n "$NAMESPACE" "$pod" -p --all-containers 2>&1 | tee -a "$logfile"
+  echo "==> 'kubectl describe' for pod $pod:" | tee -a "$logfile"
+  kubectl describe pod -n "$NAMESPACE" "$pod" 2>&1 | tee -a "$logfile"
+done
 
 if [[ $deployed -ne 1 ]]; then
   echo "==> ERROR"
-  echo "$RELEASE deployment failed; the following pods are not ready:"
-  echo "$pods"
-  kubectl get pods --all-namespaces
-  echo "==> Get logs"
-  for pod in $pods; do
-    set +e
-    logfile="${POD_LOGS}/${pod}.log"
-    echo "==> Pod logs (current instances): $pod" | tee -a "$logfile"
-    kubectl logs -n "$NAMESPACE" "$pod" --all-containers 2>&1 | tee -a "$logfile"
-    echo "==> Pod logs (previous instances): $pod" | tee -a "$logfile"
-    kubectl logs -n "$NAMESPACE" "$pod" -p --all-containers 2>&1 | tee -a "$logfile"
-    echo "==> Pod describe: $pod" | tee -a "$logfile"
-    kubectl describe pod -n "$NAMESPACE" "$pod" 2>&1 | tee -a "$logfile"
-  done
+  echo "$RELEASE deployment failed; the following pods in namespace $NAMESPACE are not OK (have status.phase != 'Running' or status.containerStatuses.ready != true):"
+  echo "$nok_pods"
   exit 1
 fi
 
-echo "==> Pods"
+echo "==> Print pod info for namespace $NAMESPACE"
 kubectl get pods -n $NAMESPACE


### PR DESCRIPTION
This PR should be merged only if it does not clutter the GH workflow log too much.